### PR TITLE
ci: remove vjudge credentials from E2E container run

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,8 +30,6 @@ jobs:
           podman run -d \
             --name ojhunt-server \
             -p 8080:8080 \
-            -e LOGIN_USERNAME__VJUDGE=${{ secrets.VJUDGE_USERNAME }} \
-            -e LOGIN_PASSWORD__VJUDGE=${{ secrets.VJUDGE_PASSWORD }} \
             ojhunt-lite
           for i in $(seq 1 30); do
             curl -sf http://localhost:8080/ && break || sleep 1


### PR DESCRIPTION
E2E tests pass without vjudge credentials — the dedup test uses synthetic data and never makes real network calls to vjudge.net.