### PR TITLE
fix(legacy): restrict user lookup to ABP username only

### DIFF
--- a/docs/adr/0006-legacy-lookup-abp-username-only.md
+++ b/docs/adr/0006-legacy-lookup-abp-username-only.md
@@ -1,0 +1,65 @@
+# ADR 0006 — Legacy Lookup Restricted to ABP Username Only
+
+**Status:** Accepted
+
+## Context
+
+`find_user` in `legacy_db.py` looked up users by matching the input string against two
+independent fields:
+
+1. `query_histories.main_username` — the OJ handle the user typed when running queries on
+   the old acm-statistics site (e.g. "tourist" on Codeforces)
+2. `users.username` — the ABP login username the user registered with on the old site
+
+These two namespaces are independent. A user's ABP login name has no required relationship
+to any OJ handle. The two-field lookup conflates them, which causes two problems:
+
+**Correctness:** If user A's ABP username happens to equal user B's OJ handle, user A's lookup
+returns user B's record from the `main_username` path. The wrong history is returned.
+
+**Privacy:** `main_username` is a publicly visible OJ handle. Accepting it as a lookup key
+allows anyone who knows a user's OJ handle to retrieve that user's cross-platform identity
+data (which OJs they use and under which handles).
+
+The UI already labels the field "the username you used on acm-statistics for logging-in",
+implying ABP-only lookup was always the intent.
+
+## Options Considered
+
+### Option A: Match ABP username only (chosen)
+
+`find_user` queries only `users.username`. `main_username` is fetched separately after the
+ABP match for use as a display name in the PDF (since the OJ handle is more recognisable in
+a competitive programming context than a site login).
+
+**Consequence:** Users who queried the old site without registering (no `users` row, only
+`query_histories` rows) lose access to their legacy data export.
+
+### Option B: Keep both, deduplicate
+
+Continue matching both fields but deduplicate results to avoid returning the same user twice.
+
+**Rejected because:** This does not fix the correctness bug — user A can still get user B's
+record if their ABP username matches user B's OJ handle.
+
+### Option C: Separate endpoints
+
+Provide two endpoints: one for ABP username lookup, one for OJ handle lookup.
+
+**Rejected because:** Over-engineered for a one-off legacy export page. The UI text already
+implies a single input type.
+
+## Decision
+
+**Option A.** `find_user` matches only on `users.username` (ABP login). `main_username` from
+`query_histories` is fetched after the match and used as the PDF display name (fallback to
+ABP username if no query history exists).
+
+## Consequences
+
+- Users who only ever queried anonymously (no account row in `users`) cannot retrieve their
+  legacy data via the web UI. This is accepted as a tradeoff.
+- The PDF display name continues to show the user's OJ handle where available, which is more
+  meaningful than the site login in a competitive programming context.
+- `find_user` no longer returns `match_type` or `main_username` — callers that previously
+  read those fields are updated to derive `main_username` independently.

--- a/docs/development.md
+++ b/docs/development.md
@@ -242,3 +242,4 @@ See those files to understand *why* things are shaped the way they are before pr
 - [ADR 0003](./adr/0003-rename-is-virtual-judge-to-is-aggregator.md) — Rename `isVirtualJudge` to `isAggregator`
 - [ADR 0004](./adr/0004-history-pdf-backup.md) — History tracking via PDF backup/restore (no database)
 - [ADR 0005](./adr/0005-localstorage-watch-config-only.md) — localStorage sync via $watch (config-only persistence)
+- [ADR 0006](./adr/0006-legacy-lookup-abp-username-only.md) — legacy lookup restricted to ABP username only

--- a/scripts/export_legacy.py
+++ b/scripts/export_legacy.py
@@ -58,7 +58,7 @@ def main() -> None:
         description="Export legacy ACM Statistics data as PDF"
     )
     parser.add_argument(
-        "username", help="Username to look up (main OJ username or site login)"
+        "username", help="ABP site login username to look up"
     )
     parser.add_argument(
         "--output", "-o", help="Output PDF path (default: <username>_legacy.pdf)"
@@ -87,10 +87,7 @@ def main() -> None:
     if args.list_matches or len(matches) > 1:
         print(f"Found {len(matches)} match(es) for '{args.username}':")
         for i, m in enumerate(matches):
-            print(
-                f"  [{i}] user_id={m['user_id']}  main={m['main_username']!r}"
-                f"  abp={m['abp_username']!r}  ({m['match_type']})"
-            )
+            print(f"  [{i}] user_id={m['user_id']}  abp={m['abp_username']!r}")
         if args.list_matches:
             return
         print(
@@ -99,14 +96,26 @@ def main() -> None:
 
     match = matches[0]
     user_id = match["user_id"]
-    main_username = match["main_username"] or match["abp_username"] or args.username
+    abp_username = match["abp_username"]
+
+    con2 = sqlite3.connect(DB_PATH)
+    try:
+        row = con2.execute(
+            "SELECT main_username FROM query_histories"
+            " WHERE user_id = ? AND main_username <> ''"
+            " ORDER BY creation_time DESC LIMIT 1",
+            (user_id,),
+        ).fetchone()
+    finally:
+        con2.close()
+    display_username = (row[0] if row else None) or abp_username or args.username
 
     output_path = (
-        Path(args.output) if args.output else Path(f"{main_username}_legacy.pdf")
+        Path(args.output) if args.output else Path(f"{display_username}_legacy.pdf")
     )
 
-    print(f"Exporting: user_id={user_id}  username={main_username!r}")
-    export_user(user_id, main_username, output_path)
+    print(f"Exporting: user_id={user_id}  username={display_username!r}")
+    export_user(user_id, display_username, output_path)
 
 
 if __name__ == "__main__":

--- a/src/ojhunt/web/legacy_db.py
+++ b/src/ojhunt/web/legacy_db.py
@@ -80,60 +80,16 @@ def _day_key_from_utc(utc_dt_str: str, iana_tz: str) -> str:
 
 
 def find_user(con: sqlite3.Connection, username: str) -> List[dict]:
-    """Find matching users by main_username or ABP username (case-insensitive).
+    """Find matching users by ABP username (case-insensitive).
 
-    Returns list of {user_id, main_username, abp_username, match_type} dicts.
+    Returns list of {user_id, abp_username} dicts.
     """
-    matches = []
     lower = username.lower()
-
-    # 1. Match by main_username in query_histories
-    rows = con.execute(
-        """
-        SELECT DISTINCT qh.user_id, qh.main_username, u.username
-        FROM query_histories qh
-        LEFT JOIN users u ON u.id = qh.user_id
-        WHERE LOWER(qh.main_username) = ?
-        """,
-        (lower,),
-    ).fetchall()
-    for user_id, main_username, abp_username in rows:
-        matches.append(
-            {
-                "user_id": user_id,
-                "main_username": main_username,
-                "abp_username": abp_username,
-                "match_type": "main_username",
-            }
-        )
-
-    # 2. Match by ABP username (if not already found)
-    found_ids = {m["user_id"] for m in matches}
     rows = con.execute(
         "SELECT id, username FROM users WHERE LOWER(username) = ?",
         (lower,),
     ).fetchall()
-    for user_id, abp_username in rows:
-        if user_id not in found_ids:
-            row = con.execute(
-                """
-                SELECT main_username FROM query_histories
-                WHERE user_id = ? AND main_username <> ''
-                ORDER BY creation_time DESC LIMIT 1
-                """,
-                (user_id,),
-            ).fetchone()
-            main_username = row[0] if row else abp_username
-            matches.append(
-                {
-                    "user_id": user_id,
-                    "main_username": main_username,
-                    "abp_username": abp_username,
-                    "match_type": "abp_username",
-                }
-            )
-
-    return matches
+    return [{"user_id": user_id, "abp_username": abp_username} for user_id, abp_username in rows]
 
 
 def get_iana_timezone(con: sqlite3.Connection, user_id: int) -> str:
@@ -297,12 +253,20 @@ def export_user_pdf(username: str) -> bytes:
 
         match = matches[0]
         user_id = match["user_id"]
-        main_username = match["main_username"] or match["abp_username"] or username
+        abp_username = match["abp_username"]
+
+        row = con.execute(
+            "SELECT main_username FROM query_histories"
+            " WHERE user_id = ? AND main_username <> ''"
+            " ORDER BY creation_time DESC LIMIT 1",
+            (user_id,),
+        ).fetchone()
+        display_username = (row[0] if row else None) or abp_username or username
 
         iana_tz = get_iana_timezone(con, user_id)
-        settings = build_settings(con, user_id, main_username)
-        history = build_history(con, user_id, iana_tz, main_username)
-        snapshot = build_snapshot(con, user_id, main_username, iana_tz)
+        settings = build_settings(con, user_id, display_username)
+        history = build_history(con, user_id, iana_tz, display_username)
+        snapshot = build_snapshot(con, user_id, display_username, iana_tz)
     finally:
         con.close()
 


### PR DESCRIPTION
Matching by main_username (OJ handle) caused a correctness bug: a user's ABP login could collide with another user's OJ handle, returning the wrong history. There was also a privacy concern since OJ handles are public.

find_user now queries only users.username (ABP). The OJ handle is still fetched from query_histories after the match and used as the PDF display name, with ABP username as fallback.

Adds ADR-0006 documenting the decision and the tradeoff (anonymous-only users without a users row lose access to their legacy export).