### PR TITLE
docs(skills): rename update-docs→update-env, add ojhunt-cli, add docs…

### DIFF
--- a/.claude/commands/update-learnings.md
+++ b/.claude/commands/update-learnings.md
@@ -16,7 +16,7 @@ Identify what was non-obvious, missing, or corrected that would help future sess
 
 ## Step 2 (silent): Route changes
 
-Invoke the `ojhunt-update-docs` skill and read it in full before deciding where
+Invoke the `ojhunt-update-env` skill and read it in full before deciding where
 each learning belongs. Do not route from memory — read the skill.
 
 ## Step 3: Show proposed changes

--- a/.claude/skills/ojhunt-cli/SKILL.md
+++ b/.claude/skills/ojhunt-cli/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: ojhunt-cli
+description: CLI entry point, argument parsing, credential handling, and output. Load whenever the task involves the CLI — reading, planning, implementing, or debugging argument parsing, query execution, credential handling, output formatting, or progress display.
+---
+
+# CLI
+
+See `docs/cli.md` for usage reference (installation, invocation, credential format, JSON output).
+
+## Running in development
+
+```bash
+uv run ojhunt tourist@codeforces
+uv run ojhunt --list
+uv run ojhunt --json tourist@codeforces
+```

--- a/.claude/skills/ojhunt-update-env/SKILL.md
+++ b/.claude/skills/ojhunt-update-env/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: ojhunt-update-docs
-description: Documentation structure and agent workflow locations. Load whenever the task involves documentation — finding where docs live, planning changes, writing or updating docs, or updating skills and commands.
+name: ojhunt-update-env
+description: Project environment structure — where each type of knowledge belongs across docs/, skills, hooks, commands, and CLAUDE.md. Load whenever the task involves documentation, creating or updating skills, adding hooks or commands, updating CLAUDE.md, or deciding where a new piece of knowledge should live.
 ---
 
-# Where to update documentation
+# Where knowledge lives in this project's environment
 
 **Single source of truth:** Each piece of knowledge lives in exactly one layer. When adding
 documentation, point to the authoritative source — don't inline definitions that already exist
@@ -29,7 +29,10 @@ in this project — not when the code changes.
 **Only document what's non-obvious.** If Claude can derive it by reading the files, or if
 it's enforced elsewhere (hook, test, linter), don't write it. Redundant entries create drift.
 
-To add a new workflow:
+**When a well-written doc file already covers the topic, the skill should be a thin pointer
+to that file plus any gotchas the doc doesn't capture. Don't replicate discoverable content.**
+
+To add a new skill:
 1. Create `.claude/skills/ojhunt-<topic>/SKILL.md` with frontmatter:
    ```
    ---
@@ -42,11 +45,15 @@ To add a new workflow:
 (e.g. `ojhunt:topic`) at the project level. Each skill must be its own top-level
 directory. Use the `ojhunt-` prefix to group related project skills.
 
+## Hooks (`.claude/hooks/` + `.claude/settings.json`)
+Hard enforcement rules — things the agent must never do or must always do automatically.
+Update when you need mechanical enforcement, not just reminders. See **ojhunt-hooks** skill.
+
 ## Commands (`.claude/commands/`)
 Project-level slash commands that override global ones.
 Create a command when the global equivalent needs project-specific context injected.
 
-`/update-learnings` — captures session learnings and routes them to the right doc layer.
+`/update-learnings` — captures session learnings and routes them to the right layer.
 
 ## `docs/adr/`
 Significant architectural decisions and their rationale. See the **ojhunt-commit** skill for
@@ -72,8 +79,8 @@ put it in a skill, not here.
 - User-facing reference → `docs/`
 - Crawler contributor reference → `docs/development.md`
 - Workflow or process → `.claude/skills/ojhunt-*/`
+- "Never do X" or "always do Y after Z" → **hook first** (see **ojhunt-hooks** skill); once hook-enforced, do NOT also add a skill entry — the hook is the enforcement, a skill note just creates drift
 - Project-level command override → `.claude/commands/`
 - Significant architectural decision (multiple approaches considered, choice non-obvious from code) → `docs/adr/`
 - Small tactical change → commit message intent (no doc needed)
-- "Never do X" or "always do Y after Z" → **hook first** (see **ojhunt-hooks** skill); once hook-enforced, do NOT also add a skill entry — the hook is the enforcement, a skill note just creates drift
 - Project-wide invariant every agent must know, regardless of task → `CLAUDE.md`

--- a/.claude/skills/ojhunt-web/SKILL.md
+++ b/.claude/skills/ojhunt-web/SKILL.md
@@ -5,6 +5,8 @@ description: FastAPI app, PDF internals, API routes, and dev server. Load whenev
 
 # Web Layer
 
+See `docs/web.md` for production deployment, container usage, and API endpoint reference.
+
 ## Running the dev server
 
 Start as a background task with sandbox disabled (file watcher and loopback networking are


### PR DESCRIPTION
… pointers

Broadens the environment concept to include docs/ alongside .claude/ artifacts. ojhunt-update-env replaces ojhunt-update-docs with a wider scope (hooks, commands, CLAUDE.md) and an explicit principle that skills should be thin pointers to docs rather than replicating discoverable content. New ojhunt-cli skill provides a thin entry point to docs/cli.md. ojhunt-web now references docs/web.md for deployment and API reference.