### PR TITLE
feat(web): add PyPI link to about page development section

### DIFF
--- a/src/ojhunt/web/templates/about.html.jinja
+++ b/src/ojhunt/web/templates/about.html.jinja
@@ -108,6 +108,11 @@
     <!-- development -->
     <div class="card">
         <div class="card-hd"><span class="prompt">&gt;</span> development</div>
+        <a class="row-item" href="https://pypi.org/project/ojhunt/" target="_blank" rel="noopener noreferrer">
+            <span class="k">pypi</span>
+            <span class="v">PyPI — ojhunt</span>
+            <span class="arr">↗</span>
+        </a>
         <a class="row-item" href="/docs" target="_blank" rel="noopener noreferrer">
             <span class="k">api docs</span>
             <span class="v">Swagger UI — /docs</span>


### PR DESCRIPTION
The about page linked to API docs, the CLI doc, and the contribute doc, but had no pointer to the published package. Add a PyPI row so visitors can reach the package to install or inspect it.

Resolves #111