### PR TITLE
build: per-worktree dev server port + orphan reaping in doit.sh

### DIFF
--- a/.claude/skills/ojhunt-web/SKILL.md
+++ b/.claude/skills/ojhunt-web/SKILL.md
@@ -16,15 +16,25 @@ Use `doit.sh` — it starts the server, waits until it's ready, and manages the 
 ./doit.sh start
 
 # Other tasks
-./doit.sh status          # check if running
+./doit.sh status          # check if running, and on which port
 ./doit.sh kill            # stop the server
 ./doit.sh logs            # tail server log
+./doit.sh reap            # kill orphaned servers whose worktree was removed
 ./doit.sh update-snapshots  # update visual regression snapshots
 ```
 
 - All `doit.sh` commands require `dangerouslyDisableSandbox: true` (loopback networking + file watcher)
 - Background tasks don't persist between conversations — restart at the beginning of each session
 - `doit.sh start` is idempotent — safe to call if already running
+- **Port depends on the checkout** (so several worktrees can run at once): the main checkout
+  uses **8080**; a git worktree gets a **dynamic free port** — run `./doit.sh status` (or read
+  `.doit/server.port`) to find it. Don't assume 8080 inside a worktree. See
+  [ADR 0009](../../../docs/adr/0009-parallel-worktree-dev-server.md).
+- **Removing a worktree leaks its server.** `./doit.sh start` auto-reaps orphans whose
+  worktree is gone (registry in the main checkout's `.doit/`); run `./doit.sh reap` to clean up
+  on demand.
+- e2e tests auto-discover the port (`OJHUNT_DEV_PORT` → `.doit/server.port` → 8080), so
+  `./doit.sh test-e2e` / `test-visual` work in any worktree.
 
 ## PDF internals
 

--- a/docs/adr/0009-parallel-worktree-dev-server.md
+++ b/docs/adr/0009-parallel-worktree-dev-server.md
@@ -1,0 +1,78 @@
+# ADR 0009 — Parallel-Worktree Dev Server (Dynamic Port + Orphan Reaping)
+
+**Status:** Accepted
+
+## Context
+
+`doit.sh` runs the local dev server on a fixed port (8080) with a single PID file under
+`.doit/`. This breaks down when development happens in several git worktrees at once (e.g.
+parallel agent jobs under `.claude/worktrees/`):
+
+1. **Port collision** — a server started in one worktree holds 8080, so `./doit.sh start` in
+   another worktree fails (or the eviction logic kills the *other* worktree's server).
+2. **Orphaned-process leak** — if a worktree is removed (`git worktree remove`, or Claude
+   Code's worktree cleanup, which calls it) while its server is still running, the process is
+   orphaned: it keeps holding its port, and its `.doit/server.pid` vanishes with the
+   directory, so nothing can stop it.
+
+The e2e tests compounded the port problem: `tests/e2e/helpers.py` hard-coded
+`BASE_URL = "http://localhost:8080"`, so tests could not target a server on any other port.
+
+## Options Considered
+
+### Port assignment
+
+- **Deterministic per-path port (e.g. `9000 + hash(path) % 1000`).** Stable and predictable,
+  but two worktrees can hash-collide onto the same port, reintroducing the collision.
+- **Pre-allocate via `socket.bind(("", 0))` in the script, then pass the number to fastapi.**
+  Rejected: this races. The script binds port 0, gets port N, *closes* the socket, and only
+  later does `fastapi dev` bind N — and `uv run fastapi` takes a second or two to start. In
+  that gap the OS can hand N to another process, which is most likely in exactly the target
+  scenario (two `./doit.sh start` runs in parallel worktrees). If the rebind then fails, the
+  start would hang.
+- **`--port 0` to `fastapi dev`, then read the bound port from the uvicorn log (chosen).**
+  uvicorn binds the ephemeral port itself and logs `Uvicorn running on http://127.0.0.1:<port>`
+  with the *actual* port. We observe that — there is no pre-allocation gap, so no race.
+  Verified that `fastapi dev --port 0` reports the real port (not `:0`), and that the listening
+  socket lives in a grandchild process (so `lsof`-on-pid discovery is unreliable, but log
+  parsing is exact and the message format is stable).
+
+### Orphan cleanup
+
+- **Git hook.** This was the first instinct, but git has *no worktree-removal hook* — hooks
+  fire on commit/checkout/push, not on `git worktree remove`. Claude Code's `WorktreeRemove`
+  setting-hook only applies to non-git isolation. So a hook cannot catch the case that
+  produces the orphan.
+- **Opportunistic reaper + registry (chosen).** A registry of running servers lives in the
+  *main* checkout's `.doit/servers.tsv` (it survives removal of any linked worktree). A `reap`
+  step kills any server whose worktree directory no longer exists and prunes dead entries. It
+  runs automatically on every `start` and is exposed as `./doit.sh reap`.
+
+## Decision
+
+- **Main checkout keeps port 8080** (stable; matches `docs/web.md`, `README.md`, and habit).
+- **Each git worktree launches `fastapi dev --port 0`**; the port uvicorn binds is read from
+  its startup log and recorded in `.doit/server.port`. A worktree is detected by its `.git`
+  being a *file* (a gitdir pointer) rather than a directory. `start` also fails fast (instead
+  of hanging) if the server process exits before it becomes ready.
+- **Tests resolve the port** from `OJHUNT_DEV_PORT` (exported by `doit.sh` test tasks),
+  falling back to `.doit/server.port`, then `8080`.
+- **Orphans are reaped opportunistically** via a central registry in the main checkout's
+  `.doit/`, on `start` and on demand via `./doit.sh reap`.
+
+The main checkout's root is resolved by parsing the worktree's `.git` pointer file
+(`gitdir: <main>/.git/worktrees/<name>`) rather than shelling out to `git`, which fails with
+"dubious ownership" when the checkout and the running user differ (e.g. an agent running as a
+separate user).
+
+## Consequences
+
+- Several worktrees can run dev servers simultaneously without colliding; `./doit.sh status`
+  reports the actual port.
+- Removing a worktree no longer leaks a server forever — the next `./doit.sh start` (or an
+  explicit `./doit.sh reap`) cleans it up. Cleanup is not instantaneous: the orphan lingers
+  until the next reap.
+- The registry is not locked; concurrent `start`/`reap` across worktrees could in principle
+  race on the TSV file. Acceptable for single-user local dev.
+- A direct `pytest` run (not via `doit.sh`) on a worktree still finds the right port through
+  the `.doit/server.port` fallback; on the main checkout it defaults to 8080 as before.

--- a/docs/development.md
+++ b/docs/development.md
@@ -218,3 +218,4 @@ Significant architectural decisions and their rationale are recorded in [`docs/a
 - [ADR 0006](./adr/0006-legacy-lookup-abp-username-only.md) — legacy lookup restricted to ABP username only
 - [ADR 0007](./adr/0007-label-cache-is-load-bearing.md) — label cache in `nit`/`uva` is load-bearing; those crawlers require the full package
 - [ADR 0008](./adr/0008-unique-solved-dedup-design.md) — unique solved dedup is problem-level; listless crawlers add raw count directly
+- [ADR 0009](./adr/0009-parallel-worktree-dev-server.md) — parallel-worktree dev server: dynamic port per worktree + orphan reaping (no git hook)

--- a/doit.sh
+++ b/doit.sh
@@ -8,10 +8,50 @@ mkdir -p "$RUN_DIR"
 
 SERVER_PID="$RUN_DIR/server.pid"
 SERVER_LOG="$RUN_DIR/server.log"
-SERVER_PORT=8080
+SERVER_PORTFILE="$RUN_DIR/server.port"
+DEFAULT_PORT=8080
+
+# A linked git worktree has a `.git` *file* (a gitdir pointer); the main checkout
+# has a `.git` *directory*. Worktrees get a dynamic port so several can run at once
+# without colliding on 8080.
+is-worktree() { [[ -f "$ROOT_DIR/.git" ]]; }
+
+# Central registry of running servers, kept in the *main* checkout's .doit/ so it
+# survives removal of any linked worktree — the source of orphaned servers. Format:
+# one TSV line per server: <pid>\t<port>\t<worktree-root>
+#
+# Resolve the main checkout's root by parsing the worktree's `.git` pointer file
+# (`gitdir: <main>/.git/worktrees/<name>`) rather than shelling out to git, which
+# can fail with "dubious ownership" when the checkout and the running user differ.
+main-root() {
+  is-worktree || { echo "$ROOT_DIR"; return; }
+  local gitdir
+  gitdir="$(sed -n 's/^gitdir: //p' "$ROOT_DIR/.git")"
+  [[ -n "$gitdir" ]] || { echo "$ROOT_DIR"; return; }
+  case "$gitdir" in /*) ;; *) gitdir="$ROOT_DIR/$gitdir" ;; esac
+  # gitdir = <main>/.git/worktrees/<name> → main root is three levels up
+  ( cd "$gitdir/../../.." 2>/dev/null && pwd ) || echo "$ROOT_DIR"
+}
+REGISTRY="$(main-root)/.doit/servers.tsv"
+
+# Port this checkout's server runs on. Recorded by `start`; defaults to 8080 when
+# no server has been started here (legacy behaviour for the main checkout).
+current-port() {
+  if [[ -f "$SERVER_PORTFILE" ]]; then cat "$SERVER_PORTFILE"; else echo "$DEFAULT_PORT"; fi
+}
+
+# Parse the port uvicorn actually bound from its startup log line:
+#   "Uvicorn running on http://127.0.0.1:<port> (Press CTRL+C to quit)"
+# We *observe* the port uvicorn chose rather than pre-allocating one. Pre-allocating
+# (bind to port 0 in the script, close, then hand the number to fastapi) races: the
+# freed port can be taken by another process — e.g. a parallel worktree's start — in
+# the gap before fastapi rebinds it.
+parse-port-from-log() {
+  sed -nE 's#.*Uvicorn running on https?://[^:]+:([0-9]+).*#\1#p' "$SERVER_LOG" | tail -1
+}
 
 is-alive() { [[ -f "$1" ]] && command kill -0 "$(cat "$1")" 2>/dev/null; }
-server-ready() { curl -s -o /dev/null "http://localhost:${SERVER_PORT}/"; }
+server-ready() { curl -s -o /dev/null "http://localhost:$(current-port)/"; }
 
 evict-port() {
   local port="$1" pids
@@ -30,24 +70,99 @@ evict-port() {
   sleep 0.2
 }
 
+register-server() {  # <pid> <port>
+  mkdir -p "$(dirname "$REGISTRY")"
+  printf '%s\t%s\t%s\n' "$1" "$2" "$ROOT_DIR" >>"$REGISTRY"
+}
+
+deregister-server() {  # drop this checkout's entries
+  [[ -f "$REGISTRY" ]] || return 0
+  local tmp; tmp="$(mktemp)"
+  awk -F'\t' -v root="$ROOT_DIR" '$3 != root' "$REGISTRY" >"$tmp" && mv "$tmp" "$REGISTRY"
+}
+
+# Kill servers whose worktree directory no longer exists (git has no
+# worktree-removal hook, so we clean up opportunistically here) and prune dead
+# entries. Runs automatically before `start`; also exposed as a task.
+reap() {
+  [[ -f "$REGISTRY" ]] || return 0
+  local tmp; tmp="$(mktemp)"
+  local pid port wt
+  while IFS=$'\t' read -r pid port wt || [[ -n "${pid:-}" ]]; do
+    [[ -z "${pid:-}" ]] && continue
+    if [[ ! -d "$wt" ]]; then
+      if command kill -0 "$pid" 2>/dev/null; then
+        pkill -TERM -P "$pid" 2>/dev/null || true
+        command kill -TERM "$pid" 2>/dev/null || true
+        echo "reaped orphaned server pid ${pid} (port ${port}) — worktree gone: ${wt}"
+      fi
+      continue  # drop entry
+    fi
+    command kill -0 "$pid" 2>/dev/null || continue  # dead pid — drop entry
+    printf '%s\t%s\t%s\n' "$pid" "$port" "$wt" >>"$tmp"  # still alive — keep
+  done <"$REGISTRY"
+  mv "$tmp" "$REGISTRY"
+}
+
 start() {
+  reap
   if is-alive "$SERVER_PID"; then
-    echo "server already running (pid $(cat "$SERVER_PID"))"
+    echo "server already running (pid $(cat "$SERVER_PID")) on port $(current-port)"
     return 0
   fi
-  rm -f "$SERVER_PID"
-  evict-port "$SERVER_PORT"
-  ( cd "$ROOT_DIR" && exec uv run fastapi dev src/ojhunt/web/app.py --port "$SERVER_PORT" ) \
+  rm -f "$SERVER_PID" "$SERVER_PORTFILE"
+  # Main checkout keeps the stable 8080 (evict a stale holder first); a git worktree
+  # asks uvicorn for a free port (--port 0) so several worktrees can run at once.
+  local port_arg=$DEFAULT_PORT
+  if is-worktree; then
+    port_arg=0
+  else
+    evict-port "$DEFAULT_PORT"
+  fi
+  # `>` truncates the log, so parse-port-from-log only ever sees this run's line.
+  ( cd "$ROOT_DIR" && exec uv run fastapi dev src/ojhunt/web/app.py --port "$port_arg" ) \
     >"$SERVER_LOG" 2>&1 &
-  echo $! >"$SERVER_PID"
-  echo "server started (pid $!) — waiting for port $SERVER_PORT..."
-  until server-ready; do sleep 0.3; done
-  echo "server ready — logs: $SERVER_LOG"
+  local pid=$!
+  echo "$pid" >"$SERVER_PID"
+  echo "server starting (pid $pid)..."
+  # Discover the port uvicorn actually bound (race-free — no pre-allocation gap).
+  local port=""
+  for _ in $(seq 1 100); do
+    if ! command kill -0 "$pid" 2>/dev/null; then
+      echo "server exited during startup — see $SERVER_LOG" >&2
+      rm -f "$SERVER_PID"
+      return 1
+    fi
+    port="$(parse-port-from-log)"
+    [[ -n "$port" ]] && break
+    sleep 0.3
+  done
+  if [[ -z "$port" ]]; then
+    echo "could not determine server port within timeout — see $SERVER_LOG" >&2
+    pkill -TERM -P "$pid" 2>/dev/null || true
+    command kill -TERM "$pid" 2>/dev/null || true
+    rm -f "$SERVER_PID"
+    return 1
+  fi
+  echo "$port" >"$SERVER_PORTFILE"
+  register-server "$pid" "$port"
+  echo "server started (pid $pid) — waiting for port $port..."
+  until server-ready; do
+    command kill -0 "$pid" 2>/dev/null || {
+      echo "server exited before becoming ready — see $SERVER_LOG" >&2
+      rm -f "$SERVER_PID" "$SERVER_PORTFILE"
+      deregister-server
+      return 1
+    }
+    sleep 0.3
+  done
+  echo "server ready on http://localhost:$port — logs: $SERVER_LOG"
 }
 
 kill() {
   if [[ ! -f "$SERVER_PID" ]]; then
     echo "server not running"
+    deregister-server
     return 0
   fi
   local pid; pid="$(cat "$SERVER_PID")"
@@ -55,20 +170,22 @@ kill() {
     pkill -TERM -P "$pid" 2>/dev/null || true
     command kill -TERM "$pid" 2>/dev/null || true
     echo "server killed (pid ${pid})"
-    rm -f "$SERVER_PID"
+    rm -f "$SERVER_PID" "$SERVER_PORTFILE"
+    deregister-server
   elif ps -p "$pid" >/dev/null 2>&1; then
     local owner; owner="$(ps -o user= -p "$pid" | tr -d ' ')"
     echo "server: pid ${pid} is alive but owned by '${owner}' — run as ${owner} to stop it. Pid file kept." >&2
     return 1
   else
     echo "server not running (stale pid file)"
-    rm -f "$SERVER_PID"
+    rm -f "$SERVER_PID" "$SERVER_PORTFILE"
+    deregister-server
   fi
 }
 
 status() {
   if is-alive "$SERVER_PID"; then
-    echo "server: running (pid $(cat "$SERVER_PID")) on port $SERVER_PORT"
+    echo "server: running (pid $(cat "$SERVER_PID")) on port $(current-port)"
   else
     echo "server: stopped"
   fi
@@ -89,7 +206,7 @@ test-e2e() {
     echo "Starting server for e2e tests..."
     start
   fi
-  ( cd "$ROOT_DIR" && uv run pytest -m playwright tests/e2e/ --ignore=tests/e2e/test_visual.py "$@" )
+  ( cd "$ROOT_DIR" && OJHUNT_DEV_PORT="$(current-port)" uv run pytest -m playwright tests/e2e/ --ignore=tests/e2e/test_visual.py "$@" )
 }
 
 test-visual() {
@@ -98,7 +215,7 @@ test-visual() {
     start
   fi
   rm -rf "$ROOT_DIR/test-results"
-  ( cd "$ROOT_DIR" && uv run pytest -m playwright tests/e2e/test_visual.py "$@" )
+  ( cd "$ROOT_DIR" && OJHUNT_DEV_PORT="$(current-port)" uv run pytest -m playwright tests/e2e/test_visual.py "$@" )
 }
 
 test-crawler() {
@@ -119,7 +236,7 @@ update-snapshots() {
   fi
   echo "Updating visual snapshots..."
   rm -rf "$ROOT_DIR/test-results"
-  ( cd "$ROOT_DIR" && uv run pytest tests/e2e/test_visual.py --update-snapshots "$@" )
+  ( cd "$ROOT_DIR" && OJHUNT_DEV_PORT="$(current-port)" uv run pytest tests/e2e/test_visual.py --update-snapshots "$@" )
   echo "Done — commit tests/e2e/__snapshots__/ alongside the change that required the update."
 }
 
@@ -128,10 +245,12 @@ help() {
 Usage: ./doit.sh <task> [args...]
 
 Server:
-  start              start the dev server on port $SERVER_PORT (waits until ready)
+  start              start the dev server (waits until ready)
+                     main checkout → port $DEFAULT_PORT; git worktree → a free port (recorded in .doit/server.port)
   kill               stop the server
-  status             show if server is running
+  status             show if server is running and on which port
   logs               tail server log
+  reap               kill orphaned servers whose git worktree has been removed
 
 Tests:
   lint               run ruff linter

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -1,8 +1,27 @@
 """Shared helpers for e2e tests."""
 
+import os
+from pathlib import Path
+
 from playwright.sync_api import Page
 
-BASE_URL = "http://localhost:8080"
+
+def _dev_server_port() -> str:
+    """Port the dev server under test is listening on.
+
+    ``doit.sh`` exports ``OJHUNT_DEV_PORT`` (git worktrees use a dynamic port);
+    fall back to the port ``doit.sh start`` recorded in ``.doit/server.port``,
+    then the legacy default ``8080`` for a plain ``pytest`` run on the main checkout.
+    """
+    port = os.environ.get("OJHUNT_DEV_PORT")
+    if not port:
+        portfile = Path(__file__).resolve().parents[2] / ".doit" / "server.port"
+        if portfile.exists():
+            port = portfile.read_text().strip()
+    return port or "8080"
+
+
+BASE_URL = f"http://localhost:{_dev_server_port()}"
 
 
 def _add_query(page: Page, crawler: str, username: str) -> None:


### PR DESCRIPTION
Running the dev server in several git worktrees at once collided on the fixed port 8080, and removing a worktree left its server orphaned with no PID file to stop it — these blocked parallel development.

Give each git worktree an OS-assigned free port (the main checkout keeps 8080 for stable docs/habits), recorded in .doit/server.port, and make the e2e tests resolve the port via OJHUNT_DEV_PORT -> .doit/server.port -> 8080 instead of hard-coding localhost:8080.

Clean up orphaned servers via a registry in the main checkout's .doit/ (which survives worktree removal): `./doit.sh start` auto-reaps, and `./doit.sh reap` does it on demand. Git fires no hook on `git worktree remove`, so reaping is opportunistic. The main checkout's root is resolved by parsing the worktree's .git pointer (not `git`, which fails with "dubious ownership" under a different user). See ADR 0009.