### PR TITLE
fix(skills): grant the -C form and stop routing the root through a va…

### DIFF
--- a/.claude/skills/ojhunt-commit/SKILL.md
+++ b/.claude/skills/ojhunt-commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ojhunt-commit
 description: Git operations, commit conventions, and ADRs. Load when preparing to commit, writing agent/worker prompts that include git steps, planning a change that may warrant an ADR, or evaluating whether a design decision needs documentation.
-allowed-tools: Read, Bash(git add:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git branch:*), Bash(git commit:*)
+allowed-tools: Read, Bash(git -C:*), Bash(git add:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git branch:*), Bash(git show:*), Bash(git commit:*), Bash(git rebase:*), Bash(git checkout:*), Bash(git reset:*), Bash(git rev-list:*), Bash(cp:*), Bash(./doit.sh:*)
 ---
 
 # Running a commit
@@ -24,11 +24,15 @@ harness injects it on every invocation as `<root>/.claude/skills/ojhunt-commit`,
 suffix and use what remains. Never hardcode the path: each worktree is its own root, and a
 hardcoded one would aim every command at a different tree.
 
+Substitute the resolved path into each command directly. Do **not** carry it in a shell variable:
+shell state does not persist between tool calls, so a `ROOT=` set in one command is empty in the
+next, and `git -C "" …` falls back to the drifted cwd — the exact bug the pin exists to prevent,
+in a form that looks defended against.
+
 ```bash
-ROOT=<this skill's base dir, minus /.claude/skills/ojhunt-commit>
-git -C "$ROOT" status --short         # staged/unstaged
-git -C "$ROOT" branch --show-current  # current branch
-git -C "$ROOT" log --oneline -10      # recent subjects, to match style
+git -C <resolved-root> status --short         # staged/unstaged
+git -C <resolved-root> branch --show-current  # current branch
+git -C <resolved-root> log --oneline -10      # recent subjects, to match style
 ```
 
 **Why pin `-C` at all:** if the session added sibling repos and any command `cd`'d into one, the


### PR DESCRIPTION
…riable

Pinning `git -C` deadened every permission grant in this skill's own frontmatter. Bash rules match on command prefix, so `git -C <root> status --short` does not begin with `git status`, and the six `Bash(git …:*)` entries stopped matching the moment the pin landed — every state-gathering command now prompts. Adds `Bash(git -C:*)`, plus the commands the body actually prescribes and the earlier list omitted: show, rebase, checkout, reset, rev-list for the squash and verification flows, cp for fixup scoping, and ./doit.sh for the per-commit checks.

`python3` and `sed` stay unlisted on purpose. Both appear in the body, but pre-approving arbitrary code execution for the whole turn is a bad trade in a commit skill; the prompt is proportionate friction.

Resolving the root from the skill's base dir is right — a literal breaks under worktrees — but carrying it in `ROOT=` is not: shell state does not persist between tool calls, and three independent read commands are exactly what gets split into parallel calls. `$ROOT` is then empty and `git -C ""` falls back to the drifted cwd, reinstating the bug the pin exists to prevent while looking defended against it. The resolved path is now substituted into each command directly.